### PR TITLE
Update the fileExists method

### DIFF
--- a/ftp.class.php
+++ b/ftp.class.php
@@ -160,7 +160,7 @@ class Ftp
 	 */
 	public function fileExists($file)
 	{
-		return is_array($this->nlist($file));
+		return (bool) $this->nlist($file);
 	}
 
 


### PR DESCRIPTION
The ftp_nlist returns an empty array in case no matching files were found.
Using is_array() will return always true even on an empty array.
But an empty array is considered as a false value, so just cast the ftp_nlist() result to boolean
